### PR TITLE
Remove empty curly brackets from Cervical Cancer Screening form

### DIFF
--- a/base/configs/openmrs/initializer_config/ampathforms/cervical_cancer_screening.json
+++ b/base/configs/openmrs/initializer_config/ampathforms/cervical_cancer_screening.json
@@ -1748,7 +1748,6 @@
               "type": "obs",
               "validators": []
             },
-            {},
             {
               "id": "breastCancerTreatment",
               "questionOptions": {


### PR DESCRIPTION
This PR fixes issues with Cervical Cancer Screening form failing to open. Refer to this convo: https://mekomsolutions.slack.com/archives/G421UNF5L/p1717492315673749?thread_ts=1717480416.495319&cid=G421UNF5L

Attachment:

[CCSForm.webm](https://github.com/mekomsolutions/ozone-distro-cambodia/assets/38831673/2758ebfd-9270-4764-a52c-3219e2003ba9)
