### PR TITLE
KH-559: Swap O3 React Form Engine with Ampath Form Engine

### DIFF
--- a/base/configs/openmrs/frontend_assembly/spa-assemble-config.json
+++ b/base/configs/openmrs/frontend_assembly/spa-assemble-config.json
@@ -1,0 +1,9 @@
+{
+    "frontendModules": {
+        "@openmrs/esm-form-entry-app": "7.1.0"
+    },
+    "__comment": "We exclude the React Form Engine app in favor of the Angular Form Engine.",
+    "frontendModuleExcludes": [
+        "@openmrs/esm-form-engine-app"
+    ]
+}


### PR DESCRIPTION
(Ref: https://mekomsolutions.atlassian.net/browse/KH-559)

Swap the O3 React Form Engine that comes by default in beta.20 with Ampath Form Engine as we are not in a position to safely QA to React Form Engine for production use.