### PR TITLE
KH-512: Add reports redirect and back up docker compose files

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -152,7 +152,7 @@
             </configuration>
           </execution>
           <execution>
-            <!-- Copy over the Override file to add reports redirect label -->
+            <!-- Copy over the reports redirect and backup files-->
             <id>Copy docker-compose-reports-redirect.yml</id>
             <phase>process-resources</phase>
             <goals>
@@ -168,28 +168,6 @@
                   <directory>${project.basedir}/scripts</directory>
                   <includes>
                     <include>docker-compose-reports-redirect.yml</include>
-                  </includes>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
-            <!-- Copy over back up Docker Compose file-->
-            <id>Copy backup.docker-compose.yml</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>
-                ${project.build.directory}/${project.artifactId}-${project.version}/run/docker/
-              </outputDirectory>
-              <overwrite>true</overwrite>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/scripts</directory>
-                  <includes>
                     <include>backup.docker-compose.yml</include>
                   </includes>
                   <filtering>true</filtering>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -151,7 +151,52 @@
               </resources>
             </configuration>
           </execution>
-
+          <execution>
+            <!-- Copy over the Docker Compose override file -->
+            <id>Copy docker-compose-reports-redirect.yml</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/${project.artifactId}-${project.version}/run/docker/
+              </outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/scripts</directory>
+                  <includes>
+                    <include>docker-compose-reports-redirect.yml</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- Copy over the Docker Compose override file -->
+            <id>Copy backup.docker-compose.yml</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/${project.artifactId}-${project.version}/run/docker/
+              </outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/scripts</directory>
+                  <includes>
+                    <include>backup.docker-compose.yml</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -152,7 +152,7 @@
             </configuration>
           </execution>
           <execution>
-            <!-- Copy over the Docker Compose override file -->
+            <!-- Copy over the Override file to add reports redirect label -->
             <id>Copy docker-compose-reports-redirect.yml</id>
             <phase>process-resources</phase>
             <goals>
@@ -175,7 +175,7 @@
             </configuration>
           </execution>
           <execution>
-            <!-- Copy over the Docker Compose override file -->
+            <!-- Copy over back up Docker Compose file-->
             <id>Copy backup.docker-compose.yml</id>
             <phase>process-resources</phase>
             <goals>

--- a/base/scripts/backup.docker-compose.yml
+++ b/base/scripts/backup.docker-compose.yml
@@ -1,0 +1,51 @@
+version: "3.7"
+
+services:
+  create-backup-folder:
+    image: busybox:latest
+    command: ["sh", "-c", "mkdir -p /mnt/$$BACKUP_FOLDER"]
+    environment:
+      BACKUP_FOLDER: ${BACKUP_FOLDER}
+    volumes:
+      - "${BACKUP_PATH:-backup-path}:/mnt"
+  #
+  # MySQL backups
+  #
+  openmrs-db-backup:
+    image: mekomsolutions/mysql_backup:48d0823
+    depends_on:
+      create-backup-folder:
+        condition: service_completed_successfully
+    environment:
+      DB_HOST: 172.17.0.1
+      DB_NAME: openmrs
+      DB_USERNAME: ${OPENMRS_DB_USER}
+      DB_PASSWORD: ${OPENMRS_DB_PASSWORD}
+      BACKUP_PATH: "/opt/backup/${BACKUP_FOLDER}"
+    networks:
+      ozone:
+        aliases:
+          - openmrs-db-backup
+    volumes:
+      - "${BACKUP_PATH:-backup-path}:/opt/backup/"
+  openmrs-checksum-backup:
+    image: mekomsolutions/filestore_backup:48d0823
+    depends_on:
+      create-backup-folder:
+        condition: service_completed_successfully
+    environment:
+      FILESTORE_PATH: /mnt/openmrs_config_checksum
+      BACKUP_PATH: "/opt/backup/${BACKUP_FOLDER}"
+      FILENAME: openmrs-checksum
+    volumes:
+      - "${BACKUP_PATH:-backup-path}:/opt/backup/"
+      - "${OPENMRS_CONFIG_CHECKSUMS_PATH:-openmrs-config-checksums}:/mnt/openmrs_config_checksum"
+
+volumes:
+  backup-path: ~
+  odoo-filestore: ~
+  odoo-checksums: ~
+  openmrs-config-checksums: ~
+
+networks:
+  ozone:

--- a/base/scripts/backup.docker-compose.yml
+++ b/base/scripts/backup.docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   create-backup-folder:
     image: busybox:latest
@@ -28,6 +26,9 @@ services:
           - openmrs-db-backup
     volumes:
       - "${BACKUP_PATH:-backup-path}:/opt/backup/"
+  #
+  # OpenMRS Initializer backups
+  #    
   openmrs-checksum-backup:
     image: mekomsolutions/filestore_backup:48d0823
     depends_on:

--- a/base/scripts/docker-compose-reports-redirect.yml
+++ b/base/scripts/docker-compose-reports-redirect.yml
@@ -1,5 +1,5 @@
 #
-# This file is needed for KH to redirect /reports to a separate Superset set instance running with and AWS domain name 
+# Needed to redirect <domain>/reports to a separate Superset instance accessible via AWS domain name 
 #
 services:
   frontend:

--- a/base/scripts/docker-compose-reports-redirect.yml
+++ b/base/scripts/docker-compose-reports-redirect.yml
@@ -1,0 +1,8 @@
+services:
+  frontend:
+    labels:
+      traefik.http.routers.reports.rule: "Host(`${O3_HOSTNAME}`) && PathPrefix(`/reports`)"  
+      traefik.http.routers.reports.entrypoints: "websecure"
+      traefik.http.routers.reports.middlewares: reports-redirectregex
+      traefik.http.middlewares.reports-redirectregex.redirectregex.regex: https://${O3_HOSTNAME}/reports
+      traefik.http.middlewares.reports-redirectregex.redirectregex.replacement: https://${SUPERSET_HOSTNAME}

--- a/base/scripts/docker-compose-reports-redirect.yml
+++ b/base/scripts/docker-compose-reports-redirect.yml
@@ -1,6 +1,5 @@
 #
 # This file is needed for KH to redirect /reports to a separate Superset set instance running with and AWS domain name 
-# since we could not get a Superset subdomain in time
 #
 services:
   frontend:

--- a/base/scripts/docker-compose-reports-redirect.yml
+++ b/base/scripts/docker-compose-reports-redirect.yml
@@ -1,3 +1,7 @@
+#
+# This file is needed for KH to redirect /reports to a separate Superset set instance running with and AWS domain name 
+# since we could not get a Superset subdomain in time
+#
 services:
   frontend:
     labels:


### PR DESCRIPTION
To prepare for deployment via https://mekomsolutions.atlassian.net/browse/KH-512. We need to add labels to redirect `/reports` path on Ozone Analytics to the Superset host. This PR also adds the backup docker compose files