### PR TITLE
KH-520: Fix failing builds on PR from forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,24 @@ on:
     types: [published]
 
 jobs:
-  validate:
+  validate-pr:
+    if: ${{ github.event_name == 'pull_request' }}
     uses: mekomsolutions/shared-github-workflow/.github/workflows/maven-build-test.yml@main
     with:
       java-version: "8"
       maven-phase: "install"
-      maven-args:
-        ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' ? '-P prod -DskipTests': '' }}
-      use-secrets:
-        ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' ? true: false }}
+    secrets:
+      NEXUS_USERNAME: ${{ secrets.MEKOM_NEXUS_USERNAME }}
+      NEXUS_PASSWORD: ${{ secrets.MEKOM_NEXUS_PASSWORD }}
+
+  validate:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    uses: mekomsolutions/shared-github-workflow/.github/workflows/maven-build-test.yml@main
+    with:
+      java-version: "8"
+      maven-phase: "install"
+      maven-args: "-P prod -DskipTests"
+      use-secrets: true
     secrets:
       NEXUS_USERNAME: ${{ secrets.MEKOM_NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.MEKOM_NEXUS_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
     with:
       java-version: "8"
       maven-phase: "install"
-    secrets:
+      maven-args: "-P validator -DskipTests"
+    secrets: # We don't the secrets here. we make them not required.
       NEXUS_USERNAME: ${{ secrets.MEKOM_NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.MEKOM_NEXUS_PASSWORD }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     with:
       java-version: "8"
       maven-phase: "install"
-      maven-args: "-P validator -DskipTests"
-    secrets: # We don't the secrets here. we make them not required.
+      maven-args: "-P validator"
+    secrets: # We don't need secrets here. we should make them not required.
       NEXUS_USERNAME: ${{ secrets.MEKOM_NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.MEKOM_NEXUS_PASSWORD }}
 
@@ -26,7 +26,7 @@ jobs:
     with:
       java-version: "8"
       maven-phase: "install"
-      maven-args: "-P prod -DskipTests"
+      maven-args: "-P prod"
       use-secrets: true
     secrets:
       NEXUS_USERNAME: ${{ secrets.MEKOM_NEXUS_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
     with:
       java-version: "8"
       maven-phase: "install"
-      maven-args: "-P prod" # Remove -Pvalidator to temporarily bypass validation
-      use-secrets: true
+      maven-args:
+        ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' ? '-P prod -DskipTests': '' }}
+      use-secrets:
+        ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' ? true: false }}
     secrets:
       NEXUS_USERNAME: ${{ secrets.MEKOM_NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.MEKOM_NEXUS_PASSWORD }}
@@ -26,7 +28,7 @@ jobs:
     uses: mekomsolutions/shared-github-workflow/.github/workflows/maven-publish.yml@main
     with:
       java-version: "8"
-      maven-args: "-P prod -DskipTests=true"
+      maven-args: "-P prod -DskipTests"
     secrets:
       NEXUS_USERNAME: ${{ secrets.MEKOM_NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.MEKOM_NEXUS_PASSWORD }}

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -248,16 +248,9 @@
     See Slack conversation:
   https://mekomsolutions.slack.com/archives/G421UNF5L/p1715787009629219?thread_ts=1715774419.673979&cid=G421UNF5L
   -->
-  <!-- <profiles>
+  <profiles>
     <profile>
       <id>validator</id>
-      <activation>
-        <jdk>1.8</jdk>
-        <property>
-          <name>env.CI</name>
-          <value>true</value>
-        </property>
-      </activation>
       <build>
         <plugins>
             <plugin>
@@ -300,5 +293,5 @@
         </plugins>
       </build>
     </profile>
-  </profiles> -->
+  </profiles>
 </project>


### PR DESCRIPTION
This PR addresses the issue of failing builds on pull requests from forked repositories. Fork repos don't have access to secrets for security reasons.
The change here ensures that `base` module is validated on PR and both on push to main since `prod` module requires access to secrets.