### PR TITLE
Update coreVersion to include fix for core translation overrides

### DIFF
--- a/base/configs/openmrs/frontend_assembly/spa-assemble-config.json
+++ b/base/configs/openmrs/frontend_assembly/spa-assemble-config.json
@@ -1,5 +1,5 @@
 {
-    "coreVersion": "5.6.1-pre.1857",
+    "coreVersion": "5.6.1-pre.1915",
     "frontendModules": {
         "@openmrs/esm-form-entry-app": "8.0.0"
     },


### PR DESCRIPTION
Updating the coreVersion from `5.6.1-pre.1857` to `5.6.1-pre.1915`.